### PR TITLE
I think the issue was that there was a colon in the title. Made the title a string in the YAML

### DIFF
--- a/site/content/events/2013-mountainview/proposals/Continuous Quality What DevOps Means for QA/index.txt
+++ b/site/content/events/2013-mountainview/proposals/Continuous Quality What DevOps Means for QA/index.txt
@@ -9,7 +9,7 @@ talk: true
 selected: false
 layout: event
 author: Jeff Sussna 
-title: Continuous Quality: What DevOps Means for QA
+title: "Continuous Quality: What DevOps Means for QA"
 ---
 
 **Abstract:**


### PR DESCRIPTION
Maded title of Continuous Quality What DevOps Means for QA talk be a string instead of bare text and the colon in the title might have been screwing with the YAML
