### PR TITLE
Update Atlanta sponsor paypal buttons to have better descriptions

### DIFF
--- a/site/content/events/2013-atlanta/sponsor/index.html
+++ b/site/content/events/2013-atlanta/sponsor/index.html
@@ -21,7 +21,7 @@ We greatly value sponsors for this open event.  If you are interested in sponsor
       <! // Silver paypal button here ->
       <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
         <input type="hidden" name="cmd" value="_s-xclick">
-        <input type="hidden" name="hosted_button_id" value="WLFFPYEC3P3BE">
+        <input type="hidden" name="hosted_button_id" value="GPUWJGRPPL4PA">
         <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
         <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
       </form>
@@ -29,7 +29,7 @@ We greatly value sponsors for this open event.  If you are interested in sponsor
       <! // Gold paypal button here ->
       <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_top">
         <input type="hidden" name="cmd" value="_s-xclick">
-        <input type="hidden" name="hosted_button_id" value="QJM6BJ8PTJ326">
+        <input type="hidden" name="hosted_button_id" value="4JP98T3S2YJLC">
         <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_paynow_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
         <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
       </form>


### PR DESCRIPTION
PayPal checkout description for sponsor levels changed to include the event name.
