### PR TITLE
fixed Tokyo event date in the google map on top page

### DIFF
--- a/site/content/index.html
+++ b/site/content/index.html
@@ -192,7 +192,7 @@ position: tokyolocation,
 draggable: false,
 raiseOnDrag: false,
 map: map,
-labelContent: "Tokyo 2013<br>11,12 October",
+labelContent: "Tokyo<br>28 September 2013",
 labelAnchor: new google.maps.Point(30, 0),
 labelClass: "labels", // the CSS class for the label
 labelStyle: {opacity: 1}


### PR DESCRIPTION
Please merge this patch to update event date in the map on top page.
