### PR TITLE
correct html syntax errors and remove inline css

### DIFF
--- a/site/content/_headermenu.txt
+++ b/site/content/_headermenu.txt
@@ -1,20 +1,26 @@
-<div id="headermenu" style="width:300px">
-<table ><tr>
-<td><center><a href="/"><img alt="home" title="home" src="/images/home.png"></a></center>
-<center><a href="/">Home</a></center></td>
-
-
-<td><center><a href="/contact/"><center><img alt="contact" title="contact" src="/images/contact.png"></a></center>
-<center><a href="/contact/">Contact</center></a></td>
-
-<td><a href="/events/"><center><img alt="events" title="events" src="/images/events.png"></a></center>
-<center><a href="/events/">Events</center></a></td>
-
-<td><a href="/presentations/"><center><img alt="presentations" title="presentations" src="/images/presentations.png"></a></center>
-<center><a href="/presentations/">Presentations</a></center></td>
-
-<td><a href="/blog/"><center><img alt="blog" title="blog" src="/images/blog.png"></a></center>
-<center><a href="/blog/">Blog</a></center></td>
-
+<div id="headermenu">
+<table >
+  <tr>
+    <td>
+      <a href="/"><img alt="home" title="home" src="/images/home.png"></a>
+      <a href="/">Home</a>
+    </td>
+    <td>
+      <a href="/contact/"><img alt="contact" title="contact" src="/images/contact.png"></a>
+      <a href="/contact/">Contact</a>
+    </td>
+    <td>
+      <a href="/events/"><img alt="events" title="events" src="/images/events.png"></a>
+      <a href="/events/">Events</a>
+    </td>
+    <td>
+      <a href="/presentations/"><img alt="presentations" title="presentations" src="/images/presentations.png"></a>
+      <a href="/presentations/">Presentations</a>
+    </td>
+    <td>
+      <a href="/blog/"><img alt="blog" title="blog" src="/images/blog.png"></a>
+      <a href="/blog/">Blog</a>
+    </td>
+  </tr>
 </table>
 </div>

--- a/site/content/css/devops.css
+++ b/site/content/css/devops.css
@@ -46,16 +46,21 @@ div#quicklinks {
 }
 
 div#quicklinks a {
-	color: white;	
+	color: white;
 	font-weight: bold;
 }
 
 div#quicklinks li {
-	list-style-type:none	
+	list-style-type:none
 }
 
 div#headermenu {
-	font-color: #1581AB;	
+	font-color: #1581AB;
+	width: 300px;
+}
+
+div#headermenu td {
+	text-align: center;
 }
 
 div#headermenu * a {

--- a/site/content/css/devops.min.css
+++ b/site/content/css/devops.min.css
@@ -387,6 +387,11 @@ div#quicklinks li {
 
 div#headermenu {
 	font-color: #1581AB;
+	width: 300px;
+}
+
+div#headermenu td {
+	text-align: center;
 }
 
 div#headermenu * a {

--- a/site/layouts/event.txt
+++ b/site/layouts/event.txt
@@ -59,7 +59,7 @@ google.load('jquery', '1.3.2');
 <div class="span-8 last">
 </div>
 
-<div class="span-24 last" id="header">
+<div class="span-24 last" id="title">
 <div class="span-15 first">
 <h1><%= @pagetitle %> </h1>
 </div>
@@ -112,7 +112,7 @@ Back to <a href='..'>proposals overview</a> - <a href='../../program'>program</a
 <% end %>
 
 </div>
-
+</div>
 
 <%= render(:partial => '/googleanalytics') %>
 <%= render(:partial => '/footer') %>


### PR DESCRIPTION
This PR is to correct html validation issues with the following areas:
- The header menu - invalid nesting of anchor and center tags
- The container div is not closed on event template
- Duplicate use of "header" id (event template, although this exists elsewhere)

I tested in Chrome and Firefox on both a Mac and PC, in Chrome on Ubuntu, and in IE11 on Windows7.  The W3C [syntax checker](http://validator.w3.org/check?uri=devopsdays.org) will still show errors, but it should show many fewer. A page like Chicago's should be free from errors after this change.  :smiley:  
