### PR TITLE
Helsinki: Fix ending time for talks on Monday

### DIFF
--- a/site/content/events/2014-helsinki/program/index.html
+++ b/site/content/events/2014-helsinki/program/index.html
@@ -32,7 +32,7 @@ Day One is about successes with devops. Hear about experiences on devops in majo
 <h3>Schedule</h3>
 08.30 - 09.30 Registration and coffee<br>
 09.30 - 09.45 Introduction<br>
-09.45 - 12.00 Talks<br>
+09.45 - 12.30 Talks<br>
 12.30 - 13.30 Lunch<br>
 13.30 - 17.00 Open space<br>
 18.00 - 21.00 Evening activities<br>


### PR DESCRIPTION
There is no empty time between lunch and end of talks.
