### PR TITLE
Added calendar of related events.

### DIFF
--- a/site/content/events/calendar/index.html
+++ b/site/content/events/calendar/index.html
@@ -1,0 +1,13 @@
+---
+extension: html
+filter:
+- erb
+- markdown
+title: Calendar
+---
+
+This calendar lists both official devopsdays events and other events which may be of interest to attendees of devopsdays. No endorsement implied; non-devopsdays events listed to assist in scheduling devopsdays.
+
+<br>
+
+<iframe src="https://www.google.com/calendar/embed?src=d3vo3hd7dr14vhlvuqshirc8n4%40group.calendar.google.com&ctz=America/Chicago" style="border: 0" width="560" height="420" frameborder="0" scrolling="no"></iframe>

--- a/site/content/events/calendar/index.html
+++ b/site/content/events/calendar/index.html
@@ -3,11 +3,11 @@ extension: html
 filter:
 - erb
 - markdown
-title: Calendar
+sidebar: false
+title: DevOps Calendar
 ---
 
-This calendar lists both official devopsdays events and other events which may be of interest to attendees of devopsdays. No endorsement implied; non-devopsdays events listed to assist in scheduling devopsdays.
+<div><h3>This community calendar lists DevOps conferences & events, including official devopsdays events but also non-devopsdays events which may be of interest to attendees of devopsdays.</h3> No endorsement implied; non-devopsdays events listed to assist in scheduling devopsdays. Calendar listed in UTC.</div>
 
 <br>
-
-<iframe src="https://www.google.com/calendar/embed?src=d3vo3hd7dr14vhlvuqshirc8n4%40group.calendar.google.com&ctz=America/Chicago" style="border: 0" width="560" height="420" frameborder="0" scrolling="no"></iframe>
+<iframe src="https://www.google.com/calendar/embed?src=devopsdays.org_9mmnk8b0qgi6va5qmuspcr4rvg%40group.calendar.google.com" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>

--- a/site/content/events/index.txt
+++ b/site/content/events/index.txt
@@ -4,63 +4,29 @@ filter:
 - erb
 - markdown
 title: Devopsdays Events
+sidebar: false
 ---
 
-Check the <a href="/events/calendar">DevOps Conferences & Events calendar</a> for relevant upcoming events.
+<div class="span-5 ">
+  <div style=" padding-top:18px;" class="span-4 last">
+    <h1>Upcoming </h1>
+  </div>
 
-The following events took place in the past:
+  <div class="span-5 ">
+    <%= render(:partial => '/future') %>
+  </div>
+</div>
 
-<ul>
-<li><a href="/events/2014-telaviv/">Tel Aviv 2014</a></li>
-<li><a href="/events/2014-vancouver/">Vancouver 2014</a></li>
-<li><a href="/events/2014-helsinki/">Helsinki 2014</a></li>
-<li><a href="/events/2014-belgium/">Belgium 2014</a></li>
-<li><a href="/events/2014-berlin/">Berlin 2014</a></li>
-<li><a href="/events/2014-chicago/">Chicago 2014</a></li>
-<li><a href="/events/2014-warsaw/">Warsaw 2014</a></li>
-<li><a href="/events/2014-newyork/">New York 2014</a></li>
-<li><a href="/events/2014-toronto/">Toronto 2014</a></li>
-<li><a href="/events/2014-boston/">Boston 2014</a></li>
-<li><a href="/events/2014-brisbane/">Brisbane 2014</a></li>
-<li><a href="/events/2014-minneapolis/">Minneapolis 2014</a></li>
-<li><a href="/events/2014-siliconvalley/">Silicon Valley 2014</a></li>
-<li><a href="/events/2014-amsterdam/">Amsterdam 2014</a></li>
-<li><a href="/events/2014-pittsburgh/">Pittsburgh 2014</a></li>
-<li><a href="/events/2014-austin/">Austin 2014</a></li>
-<li><a href="/events/2014-ljubljana/">Ljubljana 2014</a></li>
-<li><a href="/events/2014-nairobi/">Nairobi 2014</a></li>
-<li><a href="/events/2013-tokyo/">Tokyo 2013</a></li>
-<li><a href="/events/2013-telaviv/">Tel Aviv 2013</a></li>
-<li><a href="/events/2013-atlanta/">Atlanta 2013</a></li>
-<li><a href="/events/2013-newyork/">New York 2013</a></li>
-<li><a href="/events/2013-portland/">Portland 2013</a></li>
-<li><a href="/events/2013-vancouver/">Vancouver 2013</a></li>
-<li><a href="/events/2013-barcelona/">Barcelona 2013</a></li>
-<li><a href="/events/2013-london/">London Autumn 2013</a></li>
-<li><a href="/events/2013-india/">Bangalore 2013</a></li>
-<li><a href="/events/2013-downunder/">Downunder 2013</a></li>
-<li><a href="/events/2013-mountainview/">Silicon Valley 2013</a></li>
-<li><a href="/events/2013-amsterdam/">Amsterdam 2013</a></li>
-<li><a href="/events/2013-berlin/">Berlin 2013</a></li>
-<li><a href="/events/2013-austin/">Austin 2013</a></li>
-<li><a href="/events/2013-paris/">Paris 2013</a></li>
-<li><a href="/events/2013-london/">London 2013</a></li>
-<li><a href="/events/2013-newzealand/">New Zealand 2013</a></li>
-<li><a href="/events/2012-newyork/">New York 2012</a></li>
-<li><a href="/events/2012-italy/">Rome 2012</a></li>
-<li><a href="/events/2012-mountainview/">Mountain View 2012</a></li>
-<li><a href="/events/2012-india/">Delhi 2012</a></li>
-<li><a href="/events/2012-tokyo/">Tokyo 2012</a></li>
-<li><a href="/events/2012-austin/">Austin 2012</a></li>
-<li><a href="/events/2011-manila/">Manila 2011</a></li>
-<li><a href="/events/2011-goteborg/">Göteborg 2011</a></li>
-<li><a href="/events/2011-bangalore/">Bangalore 2011</a></li>
-<li><a href="http://devopsdownunder.org/">Melbourne 2011</a></li>
-<li><a href="/events/2011-mountainview/">Mountain View 2011</a></li>
-<li><a href="/events/2011-boston/">Boston 2011</a></li>
-<li><a href="/events/2010-brazil/">Sao Paulo 2010</a></li>
-<li><a href="/events/2010-europe/">Hamburg 2010</a></li>
-<li><a href="/events/2010-us/">Mountain View 2010</a></li>
-<li><a href="/events/2010-sydney/">Sydney 2010</a></li>
-<li><a href="/events/2009-ghent/">Ghent 2009</a></li>
-</ul>
+<div class="span-18 last ">
+  <div style=" padding-top:18px;" class="span-8 last">
+    <h1>Past</h1>
+  </div>
+
+  <div class="span-18 last ">
+    <%= render(:partial => '/past') %>
+  </div>
+</div>
+</div>
+
+<div><h3>The <a href="/events/calendar">DevOps Calendar</a> lists DevOps conferences & events, both devopsdays and other.</h3></div>
+

--- a/site/content/events/index.txt
+++ b/site/content/events/index.txt
@@ -5,6 +5,9 @@ filter:
 - markdown
 title: Devopsdays Events
 ---
+
+Check the <a href="/events/calendar">DevOps Conferences & Events calendar</a> for relevant upcoming events.
+
 The following events took place in the past:
 
 <ul>


### PR DESCRIPTION
I keep seeing discussions where people are trying to pick dates for their devopsdays and not being aware of other events in the same space which might affect their date selection. I'm attempting to alleviate that with this calendar (and I picked the URL to make it easy to remember/hand out).

Since this is a change to the site itself, it would be nice to have another core organizer review it (for concept/placement/idea - I've tested it technically).

![screen shot 2015-02-10 at 11 21 09 pm](https://cloud.githubusercontent.com/assets/2104453/6142425/e60eac96-b17b-11e4-8c07-3f7314c79919.png)
