### PR TITLE
Paris 2015: announcing John Willis opening keynote

### DIFF
--- a/site/content/events/2015-paris/program/index.html
+++ b/site/content/events/2015-paris/program/index.html
@@ -30,7 +30,7 @@ All of the presentations will be held in *English*.  Open spaces are participant
 <div class="span-4 append-bottom last">Introduction</div>
 <div class="span-2">10:10-10:40</div>
 <div class="span-4 box last">
-  Presentation #1
+  "Parlez-vous DevOps ?" <br /> keynote by <em>John Willis</em>
 </div>
 <div class="span-2">10:45-11:15</div>
 <div class="span-4 box last">


### PR DESCRIPTION
Announcing John Willis opening keynote in our program.

cc @phrawzty , @jooooooon 