### PR TITLE
Rearranged front-page map & ordered events.

### DIFF
--- a/site/content/_future.txt
+++ b/site/content/_future.txt
@@ -11,11 +11,11 @@
       <a href="/events/2015-newyork/">New York - April 2015</a><br/>
       <a href="/events/2015-austin">Austin - May 2015</a><br/>
       <a href="/events/2015-toronto/">Toronto - May 2015</a><br/>
-      <a href="/events/2015-amsterdam">Amsterdam - June 2015</a><br/>
-      <a href="/events/2015-derby/">Derby - Spring 2015</a><br/>
       <a href="/events/2015-washington-dc/">Washington, DC - June 2015</a><br/>
+      <a href="/events/2015-amsterdam">Amsterdam - June 2015</a><br/>
       <a href="/events/2015-minneapolis/">Minneapolis - July 2015</a><br/>
       <a href="/events/2015-chicago/">Chicago - September 2015</a><br/>
+      <a href="/events/2015-derby/">Derby - 2015</a><br/>
       Silicon Valley - Fall 2015
 </div>
   </tr>

--- a/site/content/_upcoming.txt
+++ b/site/content/_upcoming.txt
@@ -20,11 +20,11 @@
     <a href="/events/2015-austin">
       Austin
     </a>
-    -
+   <br>
     <a href="/events/2015-toronto">
       Toronto
     </a>
-   <br> 
+    -
     <a href="/events/2015-washington-dc">
       Washington, DC
     </a>

--- a/site/content/index.html
+++ b/site/content/index.html
@@ -64,7 +64,7 @@ var amsterdammarker = new MarkerWithLabel({
   draggable: false,
   raiseOnDrag: false,
   map: map,
-  labelContent: "Amsterdam 2015<br>24, 25, 26 June 2015",
+  labelContent: "Amsterdam<br>24, 25, 26 June",
   labelAnchor: new google.maps.Point(0, 45),
   labelClass: "labels", // the CSS class for the label
   labelStyle: {opacity: 1}
@@ -136,7 +136,7 @@ draggable: false,
 raiseOnDrag: false,
 map: map,
 labelContent: "Toronto<br>May 14 & 15",
-labelAnchor: new google.maps.Point(-5, 42),
+labelAnchor: new google.maps.Point(-5, 45),
 labelClass: "labels", // the CSS class for the label
 labelStyle: {opacity: 1}
 });
@@ -179,7 +179,7 @@ var dcmarker = new MarkerWithLabel({
     raiseOnDrag: false,
     map: map,
     labelContent: "Washington, DC<br>Jun 11 & 12",
-    labelAnchor: new google.maps.Point(40, 25),
+    labelAnchor: new google.maps.Point(25, 5),
     labelClass: "labels", // the CSS class for the label
     labelStyle: {opacity: 1}
 });


### PR DESCRIPTION
To prevent one event's flag from overlaying and completely covering another's. Also, putting events in the chronological order.