### PR TITLE
Charity page and link to it added

### DIFF
--- a/site/content/pages/organizing/05-After the Event/11-how-to-pay-us-back.txt
+++ b/site/content/pages/organizing/05-After the Event/11-how-to-pay-us-back.txt
@@ -13,3 +13,4 @@ We expect the following in return:
 - platinum sponsors get access to the event
 - sponsoring runs through the central devopsdays organisation
 - we appreciate money left from 'local' sponsorship. But all the sponsor money is there for your event. We're not planning to get rich on these.
+- Consider giving back to the community.  See our <a href="/pages/organizing/charity/index.html">charity</a> to get some ideas.

--- a/site/content/pages/organizing/charity/index.txt
+++ b/site/content/pages/organizing/charity/index.txt
@@ -1,0 +1,70 @@
+---
+extension: html
+filter:
+- erb
+- markdown
+title: Devopsdays Gives Back
+---
+
+<h2>Introduction</h2>
+
+<p>Below is a small summary of an open space that took place at Devopsdays Ghent (October, 2014). The goal of the open space was to find ways on how Devopsdays organizers and attendees can contribute to NGOs or other good causes.</p>
+
+<p>Two prior Devopsdays events donated some of the profits to charity.  Devopsdays NY 2014 donated to the drilling of a well in Cambodia.  Devopsdays Belgium 2014 donated to Manbarnootaaf VZW.</p>
+
+<p>Both initiatives came from persons who were on the organizing committee.  As there are many Devopsdays it maybe isn't clear that profits can be donated. Or that some other activity can be organized.  It could also be that organizers think too late of the possibility of
+donating.  This document tries to give them a head start.</p>
+
+<h2>Rationale</h2>
+
+<p>Many western countries have been hit hard by a global recession for the past few years.   While many in our countries and others have struggled, the tech sector has been experiencing a rapid boom with many jobs available which has fueled a surge in salaries, benefits, etc.   This has led to increased spending on recruiting, marketing, etc. in order to attracted the best talent and investment.</p>
+
+<p>The idea of giving back through DevOpsDays and other conferences is fueled by the recognition that we can use our very privileged status to help those in need.   The implications have the potential to be felt globally and a rising tide lifts all boats so everyone stands to benefit.</p>
+
+<p>We hope that if conferences can adopt some of the principles below, it will not only help the targets of that help, but also raise awareness within our own community of the plight of others, the impact we can have, and increase our diversity and understanding of the benefits of diversity which will help everyone.</p>
+
+<h2>Methods</h2>
+
+<p>There are several ways for organizers and attendees to give back.  What follows is a list of possible ways of doing that.</p>
+
+<p>But don’t limit yourselves --- as a Devopsdays organizer --- to the list below.  Other ways of contributing are suitable too.  It’s not bad to ask yourself the question how you can maximise number of people who benefit of the conference.  Inside and outside our communities.</p>
+
+<h3>Direct attendee commitment</h3>
+
+<ul>
+<li>Instead of giving each attendee a conference t-shirt, use that money for a donation.  An alternative could be to let attendees choose: take the t-shirt, or allow that money to be donated - this decision would need to be made before the t-shirts were produced, of course.</li>
+<li>Provide a 'charity table'.  A local charity can then install themselves in the sponsor area and try to raise money/recruit volunteers that way.</li>
+<li>Let attendees bring canned foods which can be donated to the local food bank.  An alternative could be clothes which can be donated too.</li>
+<li>Some charities need manual work.  Putting things in bags or boxes (e.g. rice, pasta).  Provide a space during open spaces for attendees to help with that.</li>
+</ul>
+
+<h3>Indirect attendee commitment</h3>
+
+<p><em>By leveraging the attendee or sponsor fees time or space can be used to engage the attendees.</em></p>
+
+<ul>
+<li>Let a charity give a short pitch so their work is visible.</li>
+<li>Reach out to the local community and sponsor a person from a community underrepresented in tech to attend the conference.</li>
+<li>Provide scholarships for local or foreign students, NGOs, non-profits, etc.</li>
+<li>Give some tickets to students and teachers.</li>
+<li>Use some of profits for a good cause.</li>
+<li>Install a donation box.</li>
+</ul>
+
+<h2>Successes Examples</h2>
+
+<p><em>hopefully this list will grow</em></p>
+
+<h3>Devopsdays</h3>
+
+<p><a href="http://mindweather.com/2014/09/18/how-devopsdays-nyc-built-a-well-for-a-village-in-cambodia-a-devopswater-update/">Devopsdays built a well in Cambodia.</a></p>
+
+<h3>non-Devopsdays</h3>
+
+<p><a href="http://www.canstruction.org/news/dreamforce-2014-cantributes-over-one-million-meals/">Dreamforce contributes over one million meals.</a></p>
+
+<h2>References</h2>
+
+<p><a href="https://www.dark.ca/2014/11/04/devopsdays-belgium-2014-recap/">Blogpost about Devopsdays Belgium 2014</a></p>
+
+<p>Salesforce 1-1-1 Model</p>

--- a/site/content/pages/organizing/index.txt
+++ b/site/content/pages/organizing/index.txt
@@ -19,6 +19,8 @@ title: Devopsdays - Organizing Guide
       :sort_by => "directory", :reverse => false)
   articles.delete(@page)
   articles.reject! {|page| page.filename.start_with?('.') }
+  # To don't show the charity dir, workaround
+  articles.reject! {|page| page.filename.start_with?('index') }
   counter = 0
   articles.sort! { |a,b| a.dir + a.filename <=> b.dir + b.filename }
 %>


### PR DESCRIPTION
Because of the autogeneration of the main organizing page we need to
exclude the charity dir.  But the only way I found was by excluding the
index.html page.  As all the other dirs do not have an index page