### PR TITLE
[URGENT dc 2015] brown paper bag typo

### DIFF
--- a/site/content/events/2015-washington-dc/_sponsors.txt
+++ b/site/content/events/2015-washington-dc/_sponsors.txt
@@ -21,7 +21,7 @@ filter:    erb
 <% end %>
 
 <% @ausponsors = [
-{ :image => "infozen.png", :name => "InfoZen", :link => "http://www.infozen.com"}
+{ :image => "infozen.png", :name => "InfoZen", :link => "http://www.infozen.com"},
 { :image => "sonatype.png", :name => "Sonatype", :link => "http://www.sonatype.com"}
 ]%>
 <% unless @ausponsors.empty?  %><h1>Gold</h1><% end %>


### PR DESCRIPTION
missed a comma in _sponsors.txt, which caused the entire DC site to be
replaced with the single word "true" - perhaps an edgy marketing
campaign but not really what we meant to do