### PR TITLE
Paris 2015: we're still accepting ignite talks

### DIFF
--- a/site/content/events/2015-paris/propose/index.html
+++ b/site/content/events/2015-paris/propose/index.html
@@ -21,6 +21,8 @@ For more information, please see our published <a href="http://www.devopsdays.or
 
 CFP was closed on **Wednesday, 4 March, 2015**.
 
+We are still accepting <a href="/pages/ignite-talks-format">Ignite sessions</a>. If you want to propose one, please send us your abstract and bio to: <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_proposals") %>"><%= render(:partial => "/#{@eventhome}/_email_proposals") %></a>
+
 ### Rules
 * Presentations are held in *English*; however, you don't need to be a native speaker (many of us aren't either).
 * Be specific! We aren't mind readers - a description of about 20 lines is about right.
@@ -42,4 +44,6 @@ CFP was closed on **Wednesday, 4 March, 2015**.
 </ol>
 
 ### Even if you don't propose, please consider [commenting on proposals submitted by others](../proposals/)
+
+
 


### PR DESCRIPTION
We didn't had a way to propose ignite talks for Paris 2015, since we closed the CfP, let's add back the proposal e-mail address.

Please merge at your convenience.
Thanks!