### PR TITLE
Missing comma turns the whole AMS 2015 site to "true".

### DIFF
--- a/site/content/events/2015-amsterdam/_sponsors.txt
+++ b/site/content/events/2015-amsterdam/_sponsors.txt
@@ -114,7 +114,7 @@ end
 		:image => "bronze-sdl.png",
 		:name => "SDL",
 		:link => "http://www.sdl.com/"
-	}
+	},
 
   {
     :image => "bronze-devoteam.png",


### PR DESCRIPTION
Because webby is very annoying. Fixed.