### PR TITLE
Adds Pittsburgh 2015 registration link

### DIFF
--- a/site/content/events/2015-pittsburgh/registration/index.html
+++ b/site/content/events/2015-pittsburgh/registration/index.html
@@ -9,4 +9,8 @@ layout : event_pitt
 title: registration
 ---
 
-<!-- <script src="//embed.showclix.com/event/embed-widget/8768280525.js"></script> -->
+<!--<script src="//embed.showclix.com/event/embed-widget/8768280525.js"></script> -->
+
+<a href="https://www.showclix.com/event/devopsdayspgh2015" border="0" style="text-decoration:none;">
+  <img src="https://s3.amazonaws.com/sc-img/10.gif" />
+</a>


### PR DESCRIPTION
We'll go live with the link, but I have a support email out to Showclix about how to get a checkout widget back. The event id numbers are apparently not the same as the number used for the widget, so I can't just change it.

@cmluciano
@littleidea
@carsomyr
@meatballhat
@sethvargo