### PR TITLE
Removes hotel link from Pittsburgh 2015

### DIFF
--- a/site/content/events/2014-pittsburgh/index.html
+++ b/site/content/events/2014-pittsburgh/index.html
@@ -27,12 +27,9 @@ And it is never too early to get excited about [Open Spaces](http://devopsdays.o
 
 ## [Register Now](registration)
 
-If you are traveling and need a place to rest your head, we have a discount block within walking distance from the venue.
-
-## [Hilton Garden Inn Hotel](http://hiltongardeninn.hilton.com/en/gi/groups/personalized/P/PITUCGI-DVO-20140528/index.jhtml?WT.mc_id=POG)
+Hotel and travel accomodations information coming soon.
 
 see you soon!
 <hr>
 
 <img border=0 width="500px" height="500px" src="warholdevops.png"><br>
-


### PR DESCRIPTION
The old link should have been removed.

@bridgetkromhout: high priority, because oops.