### PR TITLE
Removes hotel link from Pittsburgh 2015

### DIFF
--- a/site/content/events/2015-pittsburgh/index.html
+++ b/site/content/events/2015-pittsburgh/index.html
@@ -26,9 +26,7 @@ We have a [code of conduct](conduct).
 
 ## [Register Now](registration)
 
-If you are traveling and need a place to rest your head, we have a discount block within walking distance from the venue.
-
-## [Hilton Garden Inn Hotel](http://hiltongardeninn.hilton.com/en/gi/groups/personalized/P/PITUCGI-DVO-20140528/index.jhtml?WT.mc_id=POG)
+Hotel and other travel accomodation information coming soon.
 
 see you soon!
 <hr>


### PR DESCRIPTION
The old link should have been removed.

@bridgetkromhout: high priority, because oops.

**THIS IS THE CORRECT YEAR**