### PR TITLE
Fixes Ignite talk mailto link on Pittsburgh 2015 proposals

### DIFF
--- a/site/content/events/2015-pittsburgh/propose/index.html
+++ b/site/content/events/2015-pittsburgh/propose/index.html
@@ -27,4 +27,6 @@ Our fork, when available, is [here](https://github.com/cmluciano/blinder/).
 
 Ignite talks are five minute talks with twenty slides that automatically advance. [Read more about this exciting format.](http://www.devopsdays.org/pages/ignite-talks-format/)
 
-##### [Submit an **Ignite** proposal](mailto:<%= render(:partial => "/#{@eventhome}/_email_proposals") %>?subject=DoD%20PGH%20Ignite%20Proposal:%20XXXXXXXXX&body=I%20propose%20the%20following%20Ignite%20talk%20for%20DevOpsDays%20Pittsburgh%202015%3A%0A%0AMy%20name%3A%20FirstnameLastname%0AIgnite%20talk%20title%3A%20MyTalkTitle%0A)
+<h5>
+  <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_proposals") %>?subject=DoD%20PGH%20Ignite%20Proposal:%20XXXXXXXXX&amp;body=I%20propose%20the%20following%20Ignite%20talk%20for%20DevOpsDays%20Pittsburgh%202015%3A%0A%0AMy%20name%3A%20FirstnameLastname%0AIgnite%20talk%20title%3A%20MyTalkTitle%0A">Submit an **Ignite** proposal</a>
+</h5>


### PR DESCRIPTION
Markdown chokes on the newline at the end of the _email_proposals
file and munges the link. Switching to HTML fixes that.