### PR TITLE
[ams2015] Removed truncated abstracts.

### DIFF
--- a/site/content/events/2015-amsterdam/program/index.html
+++ b/site/content/events/2015-amsterdam/program/index.html
@@ -22,7 +22,6 @@ platinum: false
     <a href="http://lanyrd.com/2015/devopsams/schedule/"
         class="lanyrd-schedule"
         data-lanyrd-abstracts
-        data-lanyrd-truncateabstracts="50"
         data-lanyrd-speakers
         data-lanyrd-speakerlabels
         data-lanyrd-iframe


### PR DESCRIPTION
Workshops weren't showing in a nice way (aka. we have too many).