### PR TITLE
Moving Charlotte from "upcoming" to "future"

### DIFF
--- a/site/content/_future.txt
+++ b/site/content/_future.txt
@@ -18,6 +18,7 @@
       <a href="/events/2015-siliconvalley">Silicon Valley - Nov 2015</a><br/>
       <a href="/events/2015-detroit">Detroit - Nov 2015</a><br/>
       <a href="/events/2015-ohio/">Ohio - 2015</a><br/>
+      <a href="/events/2015-charlotte">Charlotte - 2015</a><br/>
       <a href="/events/2016-edinburgh/">Edinburgh - 2016</a><br/>
       <a href="/events/2016-seattle/">Seattle - 2016</a><br/>
 </div>

--- a/site/content/_upcoming.txt
+++ b/site/content/_upcoming.txt
@@ -39,9 +39,5 @@
     <a href="/events/2015-detroit">
       Detroit
     </a>
-    -
-    <a href="/events/2015-charlotte”>
-      Charlotte
-    </a>
   </h3>
 </div>


### PR DESCRIPTION
Moving Charlotte from "upcoming" to "future" because we put events in the legend above the map (and on the map) when a date is set. That's probably a bit ambiguous.

Also, I noticed this because an errant smartquote broke webby (yes, I know, webby is a pain) so the map was broken for the front page. Please use `webby autobuild` to check changes locally before submitting a PR. (cc @alfonso-cabrera @KrisBuytaert fyi) 