### PR TITLE
Fix broken link for upcoming SV event

### DIFF
--- a/site/content/_future.txt
+++ b/site/content/_future.txt
@@ -14,7 +14,6 @@
       <a href="/events/2015-perth/">Perth - October 2015</a><br/>
       <a href="/events/2015-berlin/">Berlin - October 2015</a><br/>
       <a href="/events/2015-singapore/">Singapore - October 2015</a><br/>
-      <a href="/events/2015-charlotte/“>Charlotte - 2015</a><br/>
       <a href="/events/2015-siliconvalley">Silicon Valley - Nov 2015</a><br/>
       <a href="/events/2015-detroit">Detroit - Nov 2015</a><br/>
       <a href="/events/2015-ohio/">Ohio - 2015</a><br/>


### PR DESCRIPTION
There is a special quote char in Charlotte URL breaking Silicon Valley url on the site.
However, this Charlotte link is actually duplicate, so removing it solves two problems.