### PR TITLE
[SIN-15] registration: Set `eventhome` variable

### DIFF
--- a/site/content/events/2015-singapore/registration/index.html
+++ b/site/content/events/2015-singapore/registration/index.html
@@ -8,6 +8,7 @@ sidebar: false
 layout : event_html5
 title: registration
 ---
+<% @eventhome = @page.directory.split(File::SEPARATOR)[0..1].join(File::SEPARATOR) %>
 
 # Registration is not open yet.<br>We plan to open it end of August.
 


### PR DESCRIPTION
This variable is needed to make hyperlinks work correctly.

Wonder if this can be set globally for each event.