### PR TITLE
[SIN-15] sponsor: Add link to 'contributor' ticket

### DIFF
--- a/site/content/events/2015-singapore/sponsor/index.html
+++ b/site/content/events/2015-singapore/sponsor/index.html
@@ -56,15 +56,10 @@ DevOpsDays Singapore 2015 will be held at the [Atrium Ballroom in the Raffles Ci
     </tr>
     <tr>
       <td></td>
-      <td>
-        Please
-        <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>?subject=devopsdays <%= @eventid %> gold sponsorship">contact us</a>
+      <td style="text-align: center">
+        <a href="https://ti.to/devopsdays-singapore/2015/with/1u8obldzrms" target="_blank">Buy here</a>
       </td>
-      <td>
-        Please
-        <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>?subject=devopsdays <%= @eventid %> gold sponsorship">contact us</a>
-      </td>
-      <td style="width:107px;vertical-align:top;padding-top:8px;">
+      <td colspan="2" style="text-align: center">
         Please
         <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>?subject=devopsdays <%= @eventid %> gold sponsorship">contact us</a>
       </td>
@@ -140,19 +135,7 @@ DevOpsDays Singapore 2015 will be held at the [Atrium Ballroom in the Raffles Ci
     </tr>
     <tr>
       <td></td>
-      <td>
-        Please
-        <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>?subject=devopsdays <%= @eventid %> Lanyard sponsorship">contact us</a>
-      </td>
-      <td>
-        Please
-        <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>?subject=devopsdays <%= @eventid %> Speaker Dinner sponsorship">contact us</a>
-      </td>
-      <td>
-        Please
-        <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>?subject=devopsdays <%= @eventid %> After Party sponsorship">contact us</a>
-      </td>
-      <td>
+      <td colspan="4" style="text-align: center">
         Please
         <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>?subject=devopsdays <%= @eventid %> Venue sponsorship">contact us</a>
       </td>


### PR DESCRIPTION
This allows visitors to buy the ticket right away.

We get a notification from ti.to and the donator also gets a reminder to
send us his logo.

Also cleaned up the 'Please contact us' links to display only a minimum.