### PR TITLE
Correction so talk can show up.

### DIFF
--- a/site/content/events/2015-siliconvalley/proposals/Empathy is transferable: How to create a culture of empathy among a dev team for DevOps and Ops/index.txt
+++ b/site/content/events/2015-siliconvalley/proposals/Empathy is transferable: How to create a culture of empathy among a dev team for DevOps and Ops/index.txt
@@ -9,7 +9,7 @@ talk: true
 ignite: false
 selected: false
 author: Speaker 51
-title: "title: "Empathy is transferable: How to create a culture of empathy among a dev team for DevOps and Ops"
+title: "Empathy is transferable: How to create a culture of empathy among a dev team for DevOps and Ops"
 ---
 
 **Abstract:**


### PR DESCRIPTION
Here's why this one wasn't showing up:

[07:05:09] ERROR: <Webby::Resources::MetaFile::Error> corrupt meta-data (perhaps there is an errant YAML marker '---' in the file)
	-- syntax error on line 11, col 39: `title: "title: "Empathy is transferable: How to create a culture of empathy among a dev team for DevOps and Ops"


This was an error introduced in https://github.com/jedi4ever/devopsdays-webby/pull/2087 - heads up to @pmoosh.