### PR TITLE
Clarifications around website updates.

### DIFF
--- a/site/content/pages/organizing/01-Getting started/03-website-and-email.txt
+++ b/site/content/pages/organizing/01-Getting started/03-website-and-email.txt
@@ -3,17 +3,20 @@ extension: html
 filter:
 - erb
 - markdown
-title: Website and Email
+title: Website, Email, and Slack
 ---
-When you have your initial team, [email the global core organizers](mailto:info@devopsdays.org) and we'll set up the @devopsdays.org mail aliases for your team. This will let you have a standard email for organizer contact and proposals. 
+When you have your initial team, [email the global core organizers](mailto:info@devopsdays.org) and we'll set up the @devopsdays.org mail aliases for your team. This will let you have a standard email for organizer contact and proposals.
+
+We prefer the city name for the actual email and site. Wider regional terms are less preferable since someone in a nearby city may want to have a devopsdays in a following year. Fun nicknames require too much dereferencing of pointers and so are best kept for slogans and t-shirt designs.
 
 The other thing you'll want to do as soon as possible is get your event listed on the website by submitting a pull request to [https://github.com/jedi4ever/devopsdays-webby](https://github.com/jedi4ever/devopsdays-webby). The simplest way to do this:
 
 - [set up webby](https://github.com/jedi4ever/devopsdays-webby/blob/master/README.md)
 - clone [https://github.com/jedi4ever/devopsdays-webby](https://github.com/jedi4ever/devopsdays-webby)
-- start from [the current year's template](https://github.com/jedi4ever/devopsdays-webby/tree/master/site/content/events/2015-template) and create your own city's page.
-- it's fine if you just list the organizers, the city, and say "coming soon". You don't have to open registration and the CFP right away.
+- start from [the current year's template](https://github.com/jedi4ever/devopsdays-webby/tree/master/site/content/events/2016-template) and create your own city's page.
+- it's fine if you just list the organizers, the city, and say "coming soon". You don't have to have the date & venue set or open registration & the CFP right away.
 - add your event to the ["Future" list](https://github.com/jedi4ever/devopsdays-webby/blob/master/site/content/_future.txt)
 - you'll be coming back to edit the [map header](https://github.com/jedi4ever/devopsdays-webby/blob/master/site/content/_upcoming.txt) and [map on the main page](https://github.com/jedi4ever/devopsdays-webby/blob/master/site/content/index.html) when your dates can be announced.
-- The [devopsdays code of conduct](http://www.devopsdays.org/events/2015-template/conduct/) is based on [the one from the Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) as well additions by Andrew Clay Shafer for [devopsdaysPGH 2014](http://www.devopsdays.org/events/2014-pittsburgh/conduct/). You will need to have a code of conduct before your initial pull request will be merged.
+- The [devopsdays code of conduct](http://www.devopsdays.org/events/2016-template/conduct/) is based on [the one from the Geek Feminism Wiki](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy) as well additions by Andrew Clay Shafer for [devopsdaysPGH 2014](http://www.devopsdays.org/events/2014-pittsburgh/conduct/). You will need to have a code of conduct before your initial pull request will be merged.
 
+Once your pull request is merged, we will add you (if desired) to the Slack team for devopsdays organizers, where you can easily share ideas with other organizers from other cities.


### PR DESCRIPTION
I'd like other core organizers to look at this PR, as I've clarified what I think has been the unwritten guidance around what we want people to call their devopsdays event and at what point of completion they can send their PR (I'm in favor of asap). I'm also explicitly inviting new organizers to Slack.