### PR TITLE
Move the label for Seattle on the map

### DIFF
--- a/site/content/js/googlemaps_content.js
+++ b/site/content/js/googlemaps_content.js
@@ -118,7 +118,7 @@ function initialize() {
     raiseOnDrag: false,
     map: map,
     labelContent: "Seattle<br>May 12 & 13",
-    labelAnchor: new google.maps.Point(0,0),
+    labelAnchor: new google.maps.Point(50,0),
     labelClass: "labels",
     labelStyle: { opacity: 1 }
   });


### PR DESCRIPTION
It does not overlap other cities and is now easier to click