### PR TITLE
etherpad from DevOpsDays DC 2015 is no more

### DIFF
--- a/site/content/events/2015-washington-dc/index.html
+++ b/site/content/events/2015-washington-dc/index.html
@@ -32,16 +32,19 @@ attendees from the private and public sectors and everywhere in between.
 If you missed the event, or if you made it to the event but missed
 anything there, here are some links to help you get briefed:
 
-* [The program](http://devopsdaysdc2015.busyconf.com/schedule)
+* [The schedule](http://devopsdaysdc2015.busyconf.com/schedule)
+* [The program](program), including:
+  * [Keynotes](program#keynotes)
+  * [Ignites](program#ignites)
+  * [Notes form open spaces](program#etherpad)
 * Some of what happened in Open Spaces: [Areas 1-4](openspaces-1234.jpg) and [Areas 5-8](openspaces-5678.jpg)
 * [Video of the keynotes and ignites](https://vimeo.com/album/3494689).
-* [Etherpad](http://e.devopsdaysdc.org) for session notes, job postings,
-and banter
+* [Session notes, job postings, and banter](program#etherpad)
 * Some Twitter searches:
-[#devopsdays](https://twitter.com/hashtag/devopsdays?src=hash),
-[#doddc](https://twitter.com/hashtag/doddc?src=hash),
-[@devopsdaysdc mentions](https://twitter.com/search?q=%40devopsdaysdc&src=savs&vertical=default&f=tweets),
-[the main @devopsdaysdc feed](https://twitter.com/devopsdaysdc).
+  * [#devopsdays](https://twitter.com/hashtag/devopsdays?src=hash),
+  * [#doddc](https://twitter.com/hashtag/doddc?src=hash),
+  * [@devopsdaysdc mentions](https://twitter.com/search?q=%40devopsdaysdc&src=savs&vertical=default&f=tweets),
+  * [the main @devopsdaysdc feed](https://twitter.com/devopsdaysdc).
 
 A special thanks to everyone who attended for helping us
 provide a harassment-free conference experience

--- a/site/content/events/2015-washington-dc/program/index.html
+++ b/site/content/events/2015-washington-dc/program/index.html
@@ -11,6 +11,7 @@ platinum: false
 
 # DevOpsDays DC - 2015
 
+<a name='keynotes'></a>
 ### Day One Keynotes
 
 * [Welcome to DevOpsDays DC](welcome.html), Nathen Harvey, DevOpsDays DC Chair and Community Director, *Chef*
@@ -21,6 +22,7 @@ platinum: false
 * [Continuous Acceleration with a Software Supply Chain Approach](corman.html), Joshua Corman, CTO, *Sonatype*
 * [Introducing Open Spaces](openspaces.html), Nathen Harvey, DevOpsDays DC Chair and Community Director, *Chef*
 
+<a name='ignites'></a>
 ### Day One Ignites
 
 * [What DevOps is Not](fayer.html), Leon Fayer, Vice President, *OmniTI*
@@ -52,6 +54,7 @@ platinum: false
 * [DevOps – Not for the faint of heart](donbeck.html), Tina Donbeck, Director, Enterprise Configuration Management Division, Office of Information Management Systems, *U.S. Patent &amp; Trademark Office*
 * [Demming's 14 Points](demming.html), John Willis, Technical Evangelist, *Docker*
 
+<a name='etherpad'></a>
 ### Notes from Open Spaces &amp; Etherpad
 
 * [Alerting and Trending](notes/Alerting_and_Trending.html)
@@ -99,12 +102,12 @@ platinum: false
 
 # More from DevOpsDays DC - 2015
 
-* [The program](http://devopsdaysdc2015.busyconf.com/schedule)
+* [The schedule](http://devopsdaysdc2015.busyconf.com/schedule)
 * Some of what happened in Open Spaces: [Areas 1-4](openspaces-1234.jpg) and [Areas 5-8](openspaces-5678.jpg)
 * [Video of the keynotes and ignites](https://vimeo.com/album/3494689).
 * [DevOpsDays Podcast](https://itunes.apple.com/us/podcast/devops-days-podcast/id1035163116?mt=2) - Audio-only versions of each keynote and ignite presentation.
 * Some Twitter searches:
-[#devopsdays](https://twitter.com/hashtag/devopsdays?src=hash),
-[#doddc](https://twitter.com/hashtag/doddc?src=hash),
-[@devopsdaysdc mentions](https://twitter.com/search?q=%40devopsdaysdc&src=savs&vertical=default&f=tweets),
-[the main @devopsdaysdc feed](https://twitter.com/devopsdaysdc).
+  * [#devopsdays](https://twitter.com/hashtag/devopsdays?src=hash),
+  * [#doddc](https://twitter.com/hashtag/doddc?src=hash),
+  * [@devopsdaysdc mentions](https://twitter.com/search?q=%40devopsdaysdc&src=savs&vertical=default&f=tweets),
+  * [the main @devopsdaysdc feed](https://twitter.com/devopsdaysdc).


### PR DESCRIPTION
* Remove any links to e.devopsdaysdc.org
* Clean-up the home and program page a bit