### PR TITLE
Update Minneapolis 2015 pages to redirect to 2016.

### DIFF
--- a/site/content/events/2015-minneapolis/index.html
+++ b/site/content/events/2015-minneapolis/index.html
@@ -13,17 +13,11 @@ dirty: true
         <center>
         <img border=0 width="200" height="200" src="./devopsmsp-logo-2015.png">
 </td><td valign=top>
-<strong>DevOpsDays is returning to Minneapolis! </strong>
+<strong>DevOpsDays Minneapolis 2016 information is available at <a href="http://www.devopsdays.org/events/2016-minneapolis/">DevOpsDays Minneapolis</a> 2016! </strong>
 <br><br>
-Dates: Wednesday & Thursday July 8-9, 2015
+DevOpsDays Minneapolis 2015 was Wednesday & Thursday July 8-9, 2015. It was held at the <a href="./location">downtown Minneapolis Hilton</a>.
 <br><br>
-Location: <a href="./location">downtown Minneapolis Hilton</a>
-<br><br>
-
-Program: <a href="./program">Check out the program</a> of 30-min talks & Ignites.
-<br><br>
-
-Registration: <a href="./registration">Add yourself to the waitlist to attend the event!</a>
+You can view the DevOpsDays Minneapolis 2015  <a href="./program">program of 30-min talks & Ignites</a>.
 <br><br>
 
 <a href="mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>">Email the organizers</a>

--- a/site/content/events/2015-minneapolis/registration/index.html
+++ b/site/content/events/2015-minneapolis/registration/index.html
@@ -9,6 +9,6 @@ title: registration
 layout: event
 ---
 
-<div style="width:100%; text-align:left;" ><iframe  src="https://devopsdaysmsp.eventbrite.com/?ref=eweb" frameborder="0" height="1000" width="100%" vspace="0" hspace="0" marginheight="5" marginwidth="5" scrolling="auto" allowtransparency="true"></iframe><div style="font-family:Helvetica, Arial; font-size:10px; padding:5px 0 5px; margin:2px; width:100%; text-align:left;" ><a style="color:#ddd; text-decoration:none;" target="_blank" href="http://www.eventbrite.com/r/eweb">Event registration</a><span style="color:#ddd;"> for </span><a style="color:#ddd; text-decoration:none;" target="_blank" href="https://devopsdaysmsp.eventbrite.com/?ref=eweb">DevOpsDays Minneapolis 2015</a> <span style="color:#ddd;">powered by</span> <a style="color:#ddd; text-decoration:none;" target="_blank" href="http://www.eventbrite.com?ref=eweb">Eventbrite</a></div></div>
+<a href="http://www.devopsdays.org/events/2016-minneapolis/registration/">Go to devopsdays Minneapolis registration for 2016</a>.
 
 </div>

--- a/site/content/events/2015-minneapolis/sponsor/index.html
+++ b/site/content/events/2015-minneapolis/sponsor/index.html
@@ -10,6 +10,10 @@ title: sponsor
 <% @eventhome = @page.directory.split(File::SEPARATOR)[0..1].join(File::SEPARATOR) %>
 <% @eventid = File.basename(@eventhome) %>
 
+
+<a href="http://www.devopsdays.org/events/2016-minneapolis/sponsor/">Go to devopsdays Minneapolis sponsorship for 2016</a>.
+
+
 We greatly value sponsors for this open event.  If you are interested in sponsoring, please check out our <a href="/events/2015-minneapolis/sponsor/devopsdaysMSP-2015-prospectus.pdf">prospectus</a> and [drop us an email](mailto:<%= render(:partial => "/#{@eventhome}/_email_organizers") %>?subject=Sponsor devopsdays <%= @eventid %>).
 
 <hr>


### PR DESCRIPTION
People think 2016 is sold out already because they are googling and getting 2015, so this should help with the confusion.