### PR TITLE
Update README-Windows.md

### DIFF
--- a/README-Windows.md
+++ b/README-Windows.md
@@ -72,7 +72,7 @@ Once the build process has finished try the website by browsing to `http://127.0
 ```
 **NOTE** 
 If you get the following message when trying to start vagrant on Windows 10, basically you may need to download and 
-install https://www.microsoft.com/en-us/download/confirmation.aspx?id=5555 on your windows machine.
+install `https://www.microsoft.com/en-us/download/confirmation.aspx?id=5555` on your windows machine.
 The Microsoft Visual C++ 2010 Redistributable Package installs runtime components of Visual C++ Libraries required 
 to run applications developed with Visual C++ on a computer that does not have Visual C++ 2010 installed.
 
@@ -118,7 +118,7 @@ Restart the FTP server
 ```
 sudo service vsftpd restart
 ```
-Test the connection to the FTP server `ftp://127.0.0.1:2021`.  If the connection is successful but you are unable to do a directory listing then there may be an issue with the passive transfer settings.
+Test the connection to the FTP server `ftp://127.0.0.1:2121`.  If the connection is successful but you are unable to do a directory listing then there may be an issue with the passive transfer settings.
 
 ### Clone the repo into the Virtual Machine
 

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -71,8 +71,10 @@ Once the build process has finished try the website by browsing to `http://127.0
 
 ```
 **NOTE** 
-If you get the following message when trying to start vagrant on Windows 10, basically you may need to download and install https://www.microsoft.com/en-us/download/confirmation.aspx?id=5555 on your windows machine.
-The Microsoft Visual C++ 2010 Redistributable Package installs runtime components of Visual C++ Libraries required to run applications developed with Visual C++ on a computer that does not have Visual C++ 2010 installed.
+If you get the following message when trying to start vagrant on Windows 10, basically you may need to download and 
+install https://www.microsoft.com/en-us/download/confirmation.aspx?id=5555 on your windows machine.
+The Microsoft Visual C++ 2010 Redistributable Package installs runtime components of Visual C++ Libraries required 
+to run applications developed with Visual C++ on a computer that does not have Visual C++ 2010 installed.
 
 The box 'bento\ubuntu-12.04' could not be found or
 could not be accessed in the remote catalog. If this is a private

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -69,6 +69,21 @@ vagrant up
 
 Once the build process has finished try the website by browsing to `http://127.0.0.1:8000`
 
+```
+**NOTE** 
+If you get the following message when trying to start vagrant on Windows 10, basically you may need to download and install https://www.microsoft.com/en-us/download/confirmation.aspx?id=5555 on your windows machine.
+The Microsoft Visual C++ 2010 Redistributable Package installs runtime components of Visual C++ Libraries required to run applications developed with Visual C++ on a computer that does not have Visual C++ 2010 installed.
+
+The box 'bento\ubuntu-12.04' could not be found or
+could not be accessed in the remote catalog. If this is a private
+box on HashiCorp's Atlas, please verify you're logged in via
+`vagrant login`. Also, please double-check the name. The expanded
+URL and error message are shown below:
+
+URL: ["https://atlas.hashicorp.com/ubuntu/precise64"]
+Error:
+```
+
 ### Install an FTP server in the Virtual Machine
 
 **Install an FTP Server**


### PR DESCRIPTION
Ran into the following issue and Aaron Blythe helped me troubleshoot this issue on Slack when he discovered the following:

Windows installer does not include MSVCP100.dll so curl does not work and so breaks vagrant · Issue #6764 · mitchellh/vagrant · GitHub

So I downloaded and installed Microsoft Visual C++ 2010 Redistributable Package (https://www.microsoft.com/en-us/download/confirmation.aspx?id=5555), then vagrant started as expected.