### PR TITLE
Removing venue-specific info for now.

### DIFF
--- a/site/content/events/2016-boston/_target_location.txt
+++ b/site/content/events/2016-boston/_target_location.txt
@@ -1,1 +1,1 @@
-Park Plaza Hotel, Boston
+Boston


### PR DESCRIPTION
Heads up to @masteinhauser - this field makes this happen:

![screen shot 2016-02-22 at 3 38 23 pm](https://cloud.githubusercontent.com/assets/2104453/13236595/55a89cca-d97a-11e5-994d-ac33640dfc64.png)
