### PR TITLE
Removing Denver organizer who stepped down.

### DIFF
--- a/site/content/events/2016-denver/_team_local.txt
+++ b/site/content/events/2016-denver/_team_local.txt
@@ -1,5 +1,4 @@
 - Tavis Aitken
 - Jason Hand
-- Matt Knox
 - Beau Christensen
 - Joe Thompson


### PR DESCRIPTION
Removing Denver organizer who stepped down.

CC @tavisto 