### PR TITLE
fixing link to keynote description

### DIFF
--- a/site/content/events/2016-atlanta/index.html
+++ b/site/content/events/2016-atlanta/index.html
@@ -23,7 +23,7 @@ dirty: true
 
 <p>
 <h3>Opening Keynote</h3>
-<strong><a href="http://localhost/events/2016-atlanta/proposals/Putting%20the%20Service%20in%20Microservices/">Putting the Service in Microservices</a></strong><br/>
+<strong><a href="http://www.devopsdays.org/events/2016-atlanta/proposals/Putting%20the%20Service%20in%20Microservices/">Putting the Service in Microservices</a></strong><br/>
 <em>by author &amp; consultant</em> <a href="https://twitter.com/jeffsussna">Jeff Sussna</a>
 </p>
 


### PR DESCRIPTION
I copied the link wrong last night. Whoops.