### PR TITLE
Changing tweetstream to whitelisted.

### DIFF
--- a/site/content/_twitterfeed.txt
+++ b/site/content/_twitterfeed.txt
@@ -1,5 +1,4 @@
 <div style="height:340px">
-<a class="twitter-timeline" href="https://twitter.com/search?q=devopsdays+OR+devopsday+OR+%23devopsday+OR+%23devopsdays" data-widget-id="345935942680469504">Tweets about "devopsdays OR devopsday OR #devopsday OR #devopsdays"</a>
+<a class="twitter-timeline" data-chrome="noheader nofooter"  data-tweet-limit=3 data-dnt="true" href="https://twitter.com/devopsdaysmsp/lists/devopsdays" data-widget-id="720829916510466048">Tweets from devopsdays events</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
 </div>
-


### PR DESCRIPTION
This changes the tweetstream to use a list (and widget) from devopsdaysMSP instead of the old search one, which got a lot of spam.

Before:
![screen shot 2016-04-14 at 10 44 52 pm](https://cloud.githubusercontent.com/assets/2104453/14551730/5c3900b6-029c-11e6-9790-d08b894238e5.png)

After:
![screen shot 2016-04-14 at 11 53 25 pm](https://cloud.githubusercontent.com/assets/2104453/14551733/65006a18-029c-11e6-978f-db5fd6cfbf25.png)

An improvement would be to make a definitive list under @devopsdays. I'd like to get this merged before Vancouver starts tomorrow so that when people are going to the site all day they won't be spammed.

Since it's a front-page change, I'd like at least one other Core team member to :+1: it.

